### PR TITLE
Various minor tweaks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,7 +34,7 @@
     -->
 
     <!-- ##### Check PHP cross-version compatibility ##### -->
-    <config name="testVersion" value="5.3-"/>
+    <config name="testVersion" value="5.6-"/>
     <rule ref="PHPCompatibility"/>
 
 
@@ -68,8 +68,14 @@
         <exclude-pattern>/classes/Autoloader\.php$</exclude-pattern>
     </rule>
 
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <!-- Don't break BC for integrations by renaming the autoloader methods. Not worth it. -->
+        <exclude-pattern>/classes/Bootstrap\.php$</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
-        <!-- Exempt the test bootstrap file from the side-effects rule. -->
+        <!-- Exempt the bootstrap files from the side-effects rule. -->
+        <exclude-pattern>/classes/Bootstrap\.php$</exclude-pattern>
         <exclude-pattern>/unitTests/bootstrap\.php$</exclude-pattern>
     </rule>
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   # @link https://getcomposer.org/doc/03-cli.md#validate
   - composer validate --no-check-all
   ## PHP_CodeSniffer
-  - if [[ "$EXTRA_CHECKS" == "1" ]]; then ./vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1 ./classes/src/ --standard=PSR2; fi
+  - if [[ "$EXTRA_CHECKS" == "1" ]]; then ./vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
   ## PHP Copy/Paste Detector
   # - if [[ "$EXTRA_CHECKS" == "1" ]]; then ./vendor/bin/phpcpd ./classes/src/; fi
   ## PHP Mess Detector

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.*",
         "phploc/phploc": "2.*",
-        "squizlabs/php_codesniffer": "^3.0.2",
+        "squizlabs/php_codesniffer": "^3.1.1",
         "wimg/php-compatibility": "^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },

--- a/unitTests/classes/src/ComplexTest.php
+++ b/unitTests/classes/src/ComplexTest.php
@@ -321,7 +321,7 @@ class ComplexTest extends \PHPUnit\Framework\TestCase
 
         // Verify that the original complex value remains unchanged
         $this->assertEquals(new Complex($args[0]), $complex);
-     }
+    }
 
     /**
      * @expectedException Exception


### PR DESCRIPTION
Saw your tweet and had a quick look through the latest changes and noticed some things being out-of-sync now.

This PR does a couple of things:
1. Bring the PHP version the PHPCompatibility standard checks against in line with the new minimum PHP version of 5.6.
2. Remove the command-line PHPCS arguments again.
3. Up the minimum PHPCS version to `3.1.1`. My bad - should have been `3.1.1` when I pulled the earlier changes. The `.`-prefix for the `phpcs.xml(.dist)` files was only introduced in this version, so if an earlier PHPCS version was being used, the config file wouldn't be picked up on automatically.
4. Very minor CS fix in one of the test files.
5. Slight tweak to the selective exclusions in the PHPCS config file.

I'm not sure why you added the command-line args again. If there was a particular reason or if you have questions about the custom ruleset, please let me know.

As for only examining the `./classes/src` files: except for the tiny fix I made in the `ComplexTest.php` file, the unit test files comply with PSR2 with some small exceptions as documented in the custom ruleset, so why exclude them ?