### PR TITLE
Composer: update select `dev` dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.*",
         "phploc/phploc": "2.*",
-        "squizlabs/php_codesniffer": "^3.1.1",
-        "wimg/php-compatibility": "^8.0",
+        "squizlabs/php_codesniffer": "^3.3.0",
+        "phpcompatibility/php-compatibility": "^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },
     "autoload": {


### PR DESCRIPTION
#### PHPCompatibility

The `PHPCompatibility` project has moved to its own GH organisation and the Packagist reference has changed accordingly.
The library has also released a new version. The release notes can be found here: https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0

#### PHP_CodeSniffer

`PHP_CodeSniffer` has released a few versions since the last update as well. Most notably version `3.2.0` introduces a new inline annotation format to selectively ignore certain sniffs.
For more details, see: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0

When these annotations were first introduced, most sniffs containing fixers were not yet adjusted to account for them. Most issues with the auto-fixers have been fixed in the subsequent 3.2.3 and 3.3.0 releases, which is why I've set the new minimum version at `3.3.0`.

#### Open questions

:point_right: If so desired, these new annotations could be implemented to replace the selective file ignores which are currently in the PHPCS ruleset.

:point_right: The unit tests file `unitTests/classes/src/functions/powTest.php` as introduced in ce35a2294a48d16904444c7edd7d15a65ef6cd45 is causing warnings because of line length violations (non build breaking).
There are three options to "solve" this:
* Actually fix it by changing the long multi-item array lines to multi-line arrays with one item on each line.
* Ignoring this particular sniff for this particular file.
* Òr adjusting the configuration for the sniff. The sniff is currently configured to `warn` about line lengths exceeding 132 characters and `error` when the line exceeds 155 characters.
    Changing the `lineLimit` property to `140` would get rid of the warnings too.