### PR TITLE
Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 
 php:
   - 7.0
+  - 7.2
   - nightly
   - hhvm
 
@@ -25,7 +26,7 @@ matrix:
   include:
     - php: 7.1
       env: EXTRA_CHECKS=1
-    - php: 7.2
+    - php: 7.3
       env: COVERAGE=1
     - php: 5.6
       env: COVERAGE=1


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev.
Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added  PHP 7.3 to the matrix.