### PR TITLE
Composer: update PHPCS dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.*",
         "phploc/phploc": "2.*",
-        "squizlabs/php_codesniffer": "^3.3.0",
-        "phpcompatibility/php-compatibility": "^8.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+        "squizlabs/php_codesniffer": "^3.4.0",
+        "phpcompatibility/php-compatibility": "^9.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },
     "autoload": {
         "psr-4": {
@@ -75,7 +75,7 @@
     },
     "scripts": {
         "style": [
-            "phpcs --report-width=200 --report-summary  --report-full classes/src/ --standard=PSR2 -n"
+            "phpcs --report-width=200 --report=summary,full -n"
         ],
         "mess": [
             "phpmd classes/src/ xml codesize,unusedcode,design,naming -n"
@@ -87,7 +87,7 @@
             "phpcpd classes/src/ -n"
         ],
         "versions": [
-            "phpcs --report-width=200 --report-summary  --report-full classes/src/ --standard=PHPCompatibility --runtime-set testVersion 5.6- -n"
+            "phpcs --report-width=200 --report=summary,full classes/src/ --standard=PHPCompatibility --runtime-set testVersion 5.6- -n"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
* PHPCompatibility has [released version 9.2.0](https://github.com/PHPCompatibility/PHPCompatibility/releases) by now, including checking for a lot of PHP 7.4 compatibility issues. You were missing out.
* Composer treats pre-1.0 minors as majors for the version negotiations, so the PHPCS installer wasn't being updated.

Other tweaks:
* `style` script: what's the point of having a `phpcs.xml.dist` config file if you're not using it ?
* phpcs scripts in general: PHPCS 3+ introduced a shorter form of setting multiple report types.