### PR TITLE
Apply function-exists check around all function definitions.

### DIFF
--- a/classes/src/functions/abs.php
+++ b/classes/src/functions/abs.php
@@ -23,7 +23,9 @@ namespace Complex;
  * @see    rho
  *
  */
-function abs($complex): float
-{
-    return rho($complex);
+if (!function_exists(__NAMESPACE__ . '\\abs')) {
+    function abs($complex): float
+    {
+        return rho($complex);
+    }
 }

--- a/classes/src/functions/acos.php
+++ b/classes/src/functions/acos.php
@@ -16,23 +16,25 @@ namespace Complex;
  * @return    Complex          The inverse cosine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function acos($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acos')) {
+    function acos($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    $square = clone $complex;
-    $square = multiply($square, $complex);
-    $invsqrt = new Complex(1.0);
-    $invsqrt = subtract($invsqrt, $square);
-    $invsqrt = sqrt($invsqrt);
-    $adjust = new Complex(
-        $complex->getReal() - $invsqrt->getImaginary(),
-        $complex->getImaginary() + $invsqrt->getReal()
-    );
-    $log = ln($adjust);
+        $square = clone $complex;
+        $square = multiply($square, $complex);
+        $invsqrt = new Complex(1.0);
+        $invsqrt = subtract($invsqrt, $square);
+        $invsqrt = sqrt($invsqrt);
+        $adjust = new Complex(
+            $complex->getReal() - $invsqrt->getImaginary(),
+            $complex->getImaginary() + $invsqrt->getReal()
+        );
+        $log = ln($adjust);
 
-    return new Complex(
-        $log->getImaginary(),
-        -1 * $log->getReal()
-    );
+        return new Complex(
+            $log->getImaginary(),
+            -1 * $log->getReal()
+        );
+    }
 }

--- a/classes/src/functions/acosh.php
+++ b/classes/src/functions/acosh.php
@@ -16,19 +16,21 @@ namespace Complex;
  * @return    Complex          The inverse hyperbolic cosine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function acosh($complex)
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acosh')) {
+    function acosh($complex)
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal() && ($complex->getReal() > 1)) {
-        return new Complex(\acosh($complex->getReal()));
+        if ($complex->isReal() && ($complex->getReal() > 1)) {
+            return new Complex(\acosh($complex->getReal()));
+        }
+
+        $acosh = acos($complex)
+            ->reverse();
+        if ($acosh->getReal() < 0.0) {
+            $acosh = $acosh->invertReal();
+        }
+
+        return $acosh;
     }
-
-    $acosh = acos($complex)
-        ->reverse();
-    if ($acosh->getReal() < 0.0) {
-        $acosh = $acosh->invertReal();
-    }
-
-    return $acosh;
 }

--- a/classes/src/functions/acot.php
+++ b/classes/src/functions/acot.php
@@ -17,9 +17,11 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function acot($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acot')) {
+    function acot($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return atan(inverse($complex));
+        return atan(inverse($complex));
+    }
 }

--- a/classes/src/functions/acoth.php
+++ b/classes/src/functions/acoth.php
@@ -17,9 +17,11 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function acoth($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acoth')) {
+    function acoth($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return atanh(inverse($complex));
+        return atanh(inverse($complex));
+    }
 }

--- a/classes/src/functions/acsc.php
+++ b/classes/src/functions/acsc.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function acsc($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acsc')) {
+    function acsc($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return asin(inverse($complex));
     }
-
-    return asin(inverse($complex));
 }

--- a/classes/src/functions/acsch.php
+++ b/classes/src/functions/acsch.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function acsch($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\acsch')) {
+    function acsch($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return asinh(inverse($complex));
     }
-
-    return asinh(inverse($complex));
 }

--- a/classes/src/functions/argument.php
+++ b/classes/src/functions/argument.php
@@ -22,7 +22,9 @@ namespace Complex;
  *
  * @see    theta
  */
-function argument($complex): float
-{
-    return theta($complex);
+if (!function_exists(__NAMESPACE__ . '\\argument')) {
+    function argument($complex): float
+    {
+        return theta($complex);
+    }
 }

--- a/classes/src/functions/asec.php
+++ b/classes/src/functions/asec.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function asec($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\asec')) {
+    function asec($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return acos(inverse($complex));
     }
-
-    return acos(inverse($complex));
 }

--- a/classes/src/functions/asech.php
+++ b/classes/src/functions/asech.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function asech($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\asech')) {
+    function asech($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return acosh(inverse($complex));
     }
-
-    return acosh(inverse($complex));
 }

--- a/classes/src/functions/asin.php
+++ b/classes/src/functions/asin.php
@@ -16,22 +16,24 @@ namespace Complex;
  * @return    Complex          The inverse sine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function asin($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\asin')) {
+    function asin($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    $square = multiply($complex, $complex);
-    $invsqrt = new Complex(1.0);
-    $invsqrt = subtract($invsqrt, $square);
-    $invsqrt = sqrt($invsqrt);
-    $adjust = new Complex(
-        $invsqrt->getReal() - $complex->getImaginary(),
-        $invsqrt->getImaginary() + $complex->getReal()
-    );
-    $log = ln($adjust);
+        $square = multiply($complex, $complex);
+        $invsqrt = new Complex(1.0);
+        $invsqrt = subtract($invsqrt, $square);
+        $invsqrt = sqrt($invsqrt);
+        $adjust = new Complex(
+            $invsqrt->getReal() - $complex->getImaginary(),
+            $invsqrt->getImaginary() + $complex->getReal()
+        );
+        $log = ln($adjust);
 
-    return new Complex(
-        $log->getImaginary(),
-        -1 * $log->getReal()
-    );
+        return new Complex(
+            $log->getImaginary(),
+            -1 * $log->getReal()
+        );
+    }
 }

--- a/classes/src/functions/asinh.php
+++ b/classes/src/functions/asinh.php
@@ -16,18 +16,20 @@ namespace Complex;
  * @return    Complex          The inverse hyperbolic sine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function asinh($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\asinh')) {
+    function asinh($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal() && ($complex->getReal() > 1)) {
-        return new Complex(\asinh($complex->getReal()));
+        if ($complex->isReal() && ($complex->getReal() > 1)) {
+            return new Complex(\asinh($complex->getReal()));
+        }
+
+        $asinh = clone $complex;
+        $asinh = $asinh->reverse()
+            ->invertReal();
+        $asinh = asin($asinh);
+        return $asinh->reverse()
+            ->invertImaginary();
     }
-
-    $asinh = clone $complex;
-    $asinh = $asinh->reverse()
-        ->invertReal();
-    $asinh = asin($asinh);
-    return $asinh->reverse()
-        ->invertImaginary();
 }

--- a/classes/src/functions/atan.php
+++ b/classes/src/functions/atan.php
@@ -20,26 +20,28 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function atan($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\atan')) {
+    function atan($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\atan($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\atan($complex->getReal()));
+        }
+
+        $t1Value = new Complex(-1 * $complex->getImaginary(), $complex->getReal());
+        $uValue = new Complex(1, 0);
+
+        $d1Value = clone $uValue;
+        $d1Value = subtract($d1Value, $t1Value);
+        $d2Value = add($t1Value, $uValue);
+        $uResult = $d1Value->divideBy($d2Value);
+        $uResult = ln($uResult);
+
+        return new Complex(
+            (($uResult->getImaginary() == M_PI) ? -M_PI : $uResult->getImaginary()) * -0.5,
+            $uResult->getReal() * 0.5,
+            $complex->getSuffix()
+        );
     }
-
-    $t1Value = new Complex(-1 * $complex->getImaginary(), $complex->getReal());
-    $uValue = new Complex(1, 0);
-
-    $d1Value = clone $uValue;
-    $d1Value = subtract($d1Value, $t1Value);
-    $d2Value = add($t1Value, $uValue);
-    $uResult = $d1Value->divideBy($d2Value);
-    $uResult = ln($uResult);
-
-    return new Complex(
-        (($uResult->getImaginary() == M_PI) ? -M_PI : $uResult->getImaginary()) * -0.5,
-        $uResult->getReal() * 0.5,
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/atanh.php
+++ b/classes/src/functions/atanh.php
@@ -16,23 +16,25 @@ namespace Complex;
  * @return    Complex          The inverse hyperbolic tangent of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function atanh($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\atanh')) {
+    function atanh($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        $real = $complex->getReal();
-        if ($real >= -1.0 && $real <= 1.0) {
-            return new Complex(\atanh($real));
-        } else {
-            return new Complex(\atanh(1 / $real), (($real < 0.0) ? M_PI_2 : -1 * M_PI_2));
+        if ($complex->isReal()) {
+            $real = $complex->getReal();
+            if ($real >= -1.0 && $real <= 1.0) {
+                return new Complex(\atanh($real));
+            } else {
+                return new Complex(\atanh(1 / $real), (($real < 0.0) ? M_PI_2 : -1 * M_PI_2));
+            }
         }
-    }
 
-    $iComplex = clone $complex;
-    $iComplex = $iComplex->invertImaginary()
-        ->reverse();
-    return atan($iComplex)
-        ->invertReal()
-        ->reverse();
+        $iComplex = clone $complex;
+        $iComplex = $iComplex->invertImaginary()
+            ->reverse();
+        return atan($iComplex)
+            ->invertReal()
+            ->reverse();
+    }
 }

--- a/classes/src/functions/conjugate.php
+++ b/classes/src/functions/conjugate.php
@@ -16,13 +16,15 @@ namespace Complex;
  * @return    Complex          The conjugate of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function conjugate($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\conjugate')) {
+    function conjugate($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return new Complex(
-        $complex->getReal(),
-        -1 * $complex->getImaginary(),
-        $complex->getSuffix()
-    );
+        return new Complex(
+            $complex->getReal(),
+            -1 * $complex->getImaginary(),
+            $complex->getSuffix()
+        );
+    }
 }

--- a/classes/src/functions/cos.php
+++ b/classes/src/functions/cos.php
@@ -16,19 +16,21 @@ namespace Complex;
  * @return    Complex          The cosine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function cos($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\cos')) {
+    function cos($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\cos($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\cos($complex->getReal()));
+        }
+
+        return conjugate(
+            new Complex(
+                \cos($complex->getReal()) * \cosh($complex->getImaginary()),
+                \sin($complex->getReal()) * \sinh($complex->getImaginary()),
+                $complex->getSuffix()
+            )
+        );
     }
-
-    return conjugate(
-        new Complex(
-            \cos($complex->getReal()) * \cosh($complex->getImaginary()),
-            \sin($complex->getReal()) * \sinh($complex->getImaginary()),
-            $complex->getSuffix()
-        )
-    );
 }

--- a/classes/src/functions/cosh.php
+++ b/classes/src/functions/cosh.php
@@ -16,17 +16,19 @@ namespace Complex;
  * @return    Complex          The hyperbolic cosine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function cosh($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\cosh')) {
+    function cosh($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\cosh($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\cosh($complex->getReal()));
+        }
+
+        return new Complex(
+            \cosh($complex->getReal()) * \cos($complex->getImaginary()),
+            \sinh($complex->getReal()) * \sin($complex->getImaginary()),
+            $complex->getSuffix()
+        );
     }
-
-    return new Complex(
-        \cosh($complex->getReal()) * \cos($complex->getImaginary()),
-        \sinh($complex->getReal()) * \sin($complex->getImaginary()),
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/cot.php
+++ b/classes/src/functions/cot.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function cot($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\cot')) {
+    function cot($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return inverse(tan($complex));
     }
-
-    return inverse(tan($complex));
 }

--- a/classes/src/functions/coth.php
+++ b/classes/src/functions/coth.php
@@ -17,8 +17,10 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function coth($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
-    return inverse(tanh($complex));
+if (!function_exists(__NAMESPACE__ . '\\coth')) {
+    function coth($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
+        return inverse(tanh($complex));
+    }
 }

--- a/classes/src/functions/csc.php
+++ b/classes/src/functions/csc.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function csc($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\csc')) {
+    function csc($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return inverse(sin($complex));
     }
-
-    return inverse(sin($complex));
 }

--- a/classes/src/functions/csch.php
+++ b/classes/src/functions/csch.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function csch($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\csch')) {
+    function csch($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        return new Complex(INF);
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            return new Complex(INF);
+        }
+
+        return inverse(sinh($complex));
     }
-
-    return inverse(sinh($complex));
 }

--- a/classes/src/functions/exp.php
+++ b/classes/src/functions/exp.php
@@ -16,19 +16,21 @@ namespace Complex;
  * @return    Complex          The exponential of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function exp($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\exp')) {
+    function exp($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if (($complex->getReal() == 0.0) && (\abs($complex->getImaginary()) == M_PI)) {
-        return new Complex(-1.0, 0.0);
+        if (($complex->getReal() == 0.0) && (\abs($complex->getImaginary()) == M_PI)) {
+            return new Complex(-1.0, 0.0);
+        }
+
+        $rho = \exp($complex->getReal());
+
+        return new Complex(
+            $rho * \cos($complex->getImaginary()),
+            $rho * \sin($complex->getImaginary()),
+            $complex->getSuffix()
+        );
     }
-
-    $rho = \exp($complex->getReal());
- 
-    return new Complex(
-        $rho * \cos($complex->getImaginary()),
-        $rho * \sin($complex->getImaginary()),
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/inverse.php
+++ b/classes/src/functions/inverse.php
@@ -17,13 +17,15 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function inverse($complex): Complex
-{
-    $complex = clone Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\inverse')) {
+    function inverse($complex): Complex
+    {
+        $complex = clone Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-        throw new \InvalidArgumentException('Division by zero');
+        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return $complex->divideInto(1.0);
     }
-
-    return $complex->divideInto(1.0);
 }

--- a/classes/src/functions/ln.php
+++ b/classes/src/functions/ln.php
@@ -17,17 +17,19 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException  If the real and the imaginary parts are both zero
  */
-function ln($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\ln')) {
+    function ln($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
-        throw new \InvalidArgumentException();
+        if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
+            throw new \InvalidArgumentException();
+        }
+
+        return new Complex(
+            \log(rho($complex)),
+            theta($complex),
+            $complex->getSuffix()
+        );
     }
-
-    return new Complex(
-        \log(rho($complex)),
-        theta($complex),
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/log10.php
+++ b/classes/src/functions/log10.php
@@ -17,16 +17,18 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException  If the real and the imaginary parts are both zero
  */
-function log10($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\log10')) {
+    function log10($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
-        throw new \InvalidArgumentException();
-    } elseif (($complex->getReal() > 0.0) && ($complex->getImaginary() == 0.0)) {
-        return new Complex(\log10($complex->getReal()), 0.0, $complex->getSuffix());
+        if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
+            throw new \InvalidArgumentException();
+        } elseif (($complex->getReal() > 0.0) && ($complex->getImaginary() == 0.0)) {
+            return new Complex(\log10($complex->getReal()), 0.0, $complex->getSuffix());
+        }
+
+        return ln($complex)
+            ->multiply(\log10(Complex::EULER));
     }
-
-    return ln($complex)
-        ->multiply(\log10(Complex::EULER));
 }

--- a/classes/src/functions/log2.php
+++ b/classes/src/functions/log2.php
@@ -17,16 +17,18 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException  If the real and the imaginary parts are both zero
  */
-function log2($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\log2')) {
+    function log2($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
-        throw new \InvalidArgumentException();
-    } elseif (($complex->getReal() > 0.0) && ($complex->getImaginary() == 0.0)) {
-        return new Complex(\log($complex->getReal(), 2), 0.0, $complex->getSuffix());
+        if (($complex->getReal() == 0.0) && ($complex->getImaginary() == 0.0)) {
+            throw new \InvalidArgumentException();
+        } elseif (($complex->getReal() > 0.0) && ($complex->getImaginary() == 0.0)) {
+            return new Complex(\log($complex->getReal(), 2), 0.0, $complex->getSuffix());
+        }
+
+        return ln($complex)
+            ->multiply(\log(Complex::EULER, 2));
     }
-
-    return ln($complex)
-        ->multiply(\log(Complex::EULER, 2));
 }

--- a/classes/src/functions/negative.php
+++ b/classes/src/functions/negative.php
@@ -19,13 +19,15 @@ namespace Complex;
  * @see    rho
  *
  */
-function negative($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\negative')) {
+    function negative($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return new Complex(
-        -1 * $complex->getReal(),
-        -1 * $complex->getImaginary(),
-        $complex->getSuffix()
-    );
+        return new Complex(
+            -1 * $complex->getReal(),
+            -1 * $complex->getImaginary(),
+            $complex->getSuffix()
+        );
+    }
 }

--- a/classes/src/functions/pow.php
+++ b/classes/src/functions/pow.php
@@ -17,24 +17,26 @@ namespace Complex;
  * @return    Complex          The complex argument raised to the real power.
  * @throws    Exception        If the power argument isn't a valid real
  */
-function pow($complex, $power): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\pow')) {
+    function pow($complex, $power): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if (!is_numeric($power)) {
-        throw new Exception('Power argument must be a real number');
+        if (!is_numeric($power)) {
+            throw new Exception('Power argument must be a real number');
+        }
+
+        if ($complex->getImaginary() == 0.0 && $complex->getReal() >= 0.0) {
+            return new Complex(\pow($complex->getReal(), $power));
+        }
+
+        $rValue = \sqrt(($complex->getReal() * $complex->getReal()) + ($complex->getImaginary() * $complex->getImaginary()));
+        $rPower = \pow($rValue, $power);
+        $theta = $complex->argument() * $power;
+        if ($theta == 0) {
+            return new Complex(1);
+        }
+
+        return new Complex($rPower * \cos($theta), $rPower * \sin($theta), $complex->getSuffix());
     }
-
-    if ($complex->getImaginary() == 0.0 && $complex->getReal() >= 0.0) {
-        return new Complex(\pow($complex->getReal(), $power));
-    }
-
-    $rValue = \sqrt(($complex->getReal() * $complex->getReal()) + ($complex->getImaginary() * $complex->getImaginary()));
-    $rPower = \pow($rValue, $power);
-    $theta = $complex->argument() * $power;
-    if ($theta == 0) {
-        return new Complex(1);
-    }
-
-    return new Complex($rPower * \cos($theta), $rPower * \sin($theta), $complex->getSuffix());
 }

--- a/classes/src/functions/rho.php
+++ b/classes/src/functions/rho.php
@@ -17,12 +17,14 @@ namespace Complex;
  * @return    float            The rho value of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function rho($complex): float
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\rho')) {
+    function rho($complex): float
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return \sqrt(
-        ($complex->getReal() * $complex->getReal()) +
-        ($complex->getImaginary() * $complex->getImaginary())
-    );
+        return \sqrt(
+            ($complex->getReal() * $complex->getReal()) +
+            ($complex->getImaginary() * $complex->getImaginary())
+        );
+    }
 }

--- a/classes/src/functions/sec.php
+++ b/classes/src/functions/sec.php
@@ -17,9 +17,11 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function sec($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\sec')) {
+    function sec($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return inverse(cos($complex));
+        return inverse(cos($complex));
+    }
 }

--- a/classes/src/functions/sech.php
+++ b/classes/src/functions/sech.php
@@ -17,9 +17,11 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function sech($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\sech')) {
+    function sech($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    return inverse(cosh($complex));
+        return inverse(cosh($complex));
+    }
 }

--- a/classes/src/functions/sin.php
+++ b/classes/src/functions/sin.php
@@ -16,17 +16,19 @@ namespace Complex;
  * @return    Complex          The sine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function sin($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\sin')) {
+    function sin($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\sin($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\sin($complex->getReal()));
+        }
+
+        return new Complex(
+            \sin($complex->getReal()) * \cosh($complex->getImaginary()),
+            \cos($complex->getReal()) * \sinh($complex->getImaginary()),
+            $complex->getSuffix()
+        );
     }
-
-    return new Complex(
-        \sin($complex->getReal()) * \cosh($complex->getImaginary()),
-        \cos($complex->getReal()) * \sinh($complex->getImaginary()),
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/sinh.php
+++ b/classes/src/functions/sinh.php
@@ -16,17 +16,19 @@ namespace Complex;
  * @return    Complex          The hyperbolic sine of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function sinh($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\sinh')) {
+    function sinh($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\sinh($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\sinh($complex->getReal()));
+        }
+
+        return new Complex(
+            \sinh($complex->getReal()) * \cos($complex->getImaginary()),
+            \cosh($complex->getReal()) * \sin($complex->getImaginary()),
+            $complex->getSuffix()
+        );
     }
-
-    return new Complex(
-        \sinh($complex->getReal()) * \cos($complex->getImaginary()),
-        \cosh($complex->getReal()) * \sin($complex->getImaginary()),
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/sqrt.php
+++ b/classes/src/functions/sqrt.php
@@ -16,14 +16,16 @@ namespace Complex;
  * @return    Complex          The Square root of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function sqrt($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\sqrt')) {
+    function sqrt($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    $theta = theta($complex);
-    $delta1 = \cos($theta / 2);
-    $delta2 = \sin($theta / 2);
-    $rho = \sqrt(rho($complex));
+        $theta = theta($complex);
+        $delta1 = \cos($theta / 2);
+        $delta2 = \sin($theta / 2);
+        $rho = \sqrt(rho($complex));
 
-    return new Complex($delta1 * $rho, $delta2 * $rho, $complex->getSuffix());
+        return new Complex($delta1 * $rho, $delta2 * $rho, $complex->getSuffix());
+    }
 }

--- a/classes/src/functions/tan.php
+++ b/classes/src/functions/tan.php
@@ -17,24 +17,26 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function tan($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\tan')) {
+    function tan($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->isReal()) {
-        return new Complex(\tan($complex->getReal()));
+        if ($complex->isReal()) {
+            return new Complex(\tan($complex->getReal()));
+        }
+
+        $real = $complex->getReal();
+        $imaginary = $complex->getImaginary();
+        $divisor = 1 + \pow(\tan($real), 2) * \pow(\tanh($imaginary), 2);
+        if ($divisor == 0.0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return new Complex(
+            \pow(sech($imaginary)->getReal(), 2) * \tan($real) / $divisor,
+            \pow(sec($real)->getReal(), 2) * \tanh($imaginary) / $divisor,
+            $complex->getSuffix()
+        );
     }
-
-    $real = $complex->getReal();
-    $imaginary = $complex->getImaginary();
-    $divisor = 1 + \pow(\tan($real), 2) * \pow(\tanh($imaginary), 2);
-    if ($divisor == 0.0) {
-        throw new \InvalidArgumentException('Division by zero');
-    }
-
-    return new Complex(
-        \pow(sech($imaginary)->getReal(), 2) * \tan($real) / $divisor,
-        \pow(sec($real)->getReal(), 2) * \tanh($imaginary) / $divisor,
-        $complex->getSuffix()
-    );
 }

--- a/classes/src/functions/tanh.php
+++ b/classes/src/functions/tanh.php
@@ -17,19 +17,21 @@ namespace Complex;
  * @throws    Exception        If argument isn't a valid real or complex number.
  * @throws    \InvalidArgumentException    If function would result in a division by zero
  */
-function tanh($complex): Complex
-{
-    $complex = Complex::validateComplexArgument($complex);
-    $real = $complex->getReal();
-    $imaginary = $complex->getImaginary();
-    $divisor = \cos($imaginary) * \cos($imaginary) + \sinh($real) * \sinh($real);
-    if ($divisor == 0.0) {
-        throw new \InvalidArgumentException('Division by zero');
-    }
+if (!function_exists(__NAMESPACE__ . '\\tanh')) {
+    function tanh($complex): Complex
+    {
+        $complex = Complex::validateComplexArgument($complex);
+        $real = $complex->getReal();
+        $imaginary = $complex->getImaginary();
+        $divisor = \cos($imaginary) * \cos($imaginary) + \sinh($real) * \sinh($real);
+        if ($divisor == 0.0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
 
-    return new Complex(
-        \sinh($real) * \cosh($real) / $divisor,
-        0.5 * \sin(2 * $imaginary) / $divisor,
-        $complex->getSuffix()
-    );
+        return new Complex(
+            \sinh($real) * \cosh($real) / $divisor,
+            0.5 * \sin(2 * $imaginary) / $divisor,
+            $complex->getSuffix()
+        );
+    }
 }

--- a/classes/src/functions/theta.php
+++ b/classes/src/functions/theta.php
@@ -17,22 +17,24 @@ namespace Complex;
  * @return    float            The theta value of the complex argument.
  * @throws    Exception        If argument isn't a valid real or complex number.
  */
-function theta($complex): float
-{
-    $complex = Complex::validateComplexArgument($complex);
+if (!function_exists(__NAMESPACE__ . '\\theta')) {
+    function theta($complex): float
+    {
+        $complex = Complex::validateComplexArgument($complex);
 
-    if ($complex->getReal() == 0.0) {
-        if ($complex->isReal()) {
-            return 0.0;
+        if ($complex->getReal() == 0.0) {
+            if ($complex->isReal()) {
+                return 0.0;
+            } elseif ($complex->getImaginary() < 0.0) {
+                return M_PI / -2;
+            }
+            return M_PI / 2;
+        } elseif ($complex->getReal() > 0.0) {
+            return \atan($complex->getImaginary() / $complex->getReal());
         } elseif ($complex->getImaginary() < 0.0) {
-            return M_PI / -2;
+            return -(M_PI - \atan(\abs($complex->getImaginary()) / \abs($complex->getReal())));
         }
-        return M_PI / 2;
-    } elseif ($complex->getReal() > 0.0) {
-        return \atan($complex->getImaginary() / $complex->getReal());
-    } elseif ($complex->getImaginary() < 0.0) {
-        return -(M_PI - \atan(\abs($complex->getImaginary()) / \abs($complex->getReal())));
-    }
 
-    return M_PI - \atan($complex->getImaginary() / \abs($complex->getReal()));
+        return M_PI - \atan($complex->getImaginary() / \abs($complex->getReal()));
+    }
 }

--- a/classes/src/operations/add.php
+++ b/classes/src/operations/add.php
@@ -15,32 +15,34 @@ namespace Complex;
  * @param     array of string|integer|float|Complex    $complexValues   The numbers to add
  * @return    Complex
  */
-function add(...$complexValues): Complex
-{
-    if (count($complexValues) < 2) {
-        throw new \Exception('This function requires at least 2 arguments');
-    }
-
-    $base = array_shift($complexValues);
-    $result = clone Complex::validateComplexArgument($base);
-
-    foreach ($complexValues as $complex) {
-        $complex = Complex::validateComplexArgument($complex);
-
-        if ($result->isComplex() && $complex->isComplex() &&
-            $result->getSuffix() !== $complex->getSuffix()) {
-            throw new Exception('Suffix Mismatch');
+if (!function_exists(__NAMESPACE__ . '\\add')) {
+    function add(...$complexValues): Complex
+    {
+        if (count($complexValues) < 2) {
+            throw new \Exception('This function requires at least 2 arguments');
         }
 
-        $real = $result->getReal() + $complex->getReal();
-        $imaginary = $result->getImaginary() + $complex->getImaginary();
+        $base = array_shift($complexValues);
+        $result = clone Complex::validateComplexArgument($base);
 
-        $result = new Complex(
-            $real,
-            $imaginary,
-            ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
-        );
+        foreach ($complexValues as $complex) {
+            $complex = Complex::validateComplexArgument($complex);
+
+            if ($result->isComplex() && $complex->isComplex() &&
+                $result->getSuffix() !== $complex->getSuffix()) {
+                throw new Exception('Suffix Mismatch');
+            }
+
+            $real = $result->getReal() + $complex->getReal();
+            $imaginary = $result->getImaginary() + $complex->getImaginary();
+
+            $result = new Complex(
+                $real,
+                $imaginary,
+                ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
+            );
+        }
+
+        return $result;
     }
-
-    return $result;
 }

--- a/classes/src/operations/divideby.php
+++ b/classes/src/operations/divideby.php
@@ -15,42 +15,44 @@ namespace Complex;
  * @param     array of string|integer|float|Complex    $complexValues   The numbers to divide
  * @return    Complex
  */
-function divideby(...$complexValues): Complex
-{
-    if (count($complexValues) < 2) {
-        throw new \Exception('This function requires at least 2 arguments');
-    }
-
-    $base = array_shift($complexValues);
-    $result = clone Complex::validateComplexArgument($base);
-
-    foreach ($complexValues as $complex) {
-        $complex = Complex::validateComplexArgument($complex);
-
-        if ($result->isComplex() && $complex->isComplex() &&
-            $result->getSuffix() !== $complex->getSuffix()) {
-            throw new Exception('Suffix Mismatch');
-        }
-        if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
-            throw new \InvalidArgumentException('Division by zero');
+if (!function_exists(__NAMESPACE__ . '\\divideby')) {
+    function divideby(...$complexValues): Complex
+    {
+        if (count($complexValues) < 2) {
+            throw new \Exception('This function requires at least 2 arguments');
         }
 
-        $delta1 = ($result->getReal() * $complex->getReal()) +
-            ($result->getImaginary() * $complex->getImaginary());
-        $delta2 = ($result->getImaginary() * $complex->getReal()) -
-            ($result->getReal() * $complex->getImaginary());
-        $delta3 = ($complex->getReal() * $complex->getReal()) +
-            ($complex->getImaginary() * $complex->getImaginary());
+        $base = array_shift($complexValues);
+        $result = clone Complex::validateComplexArgument($base);
 
-        $real = $delta1 / $delta3;
-        $imaginary = $delta2 / $delta3;
+        foreach ($complexValues as $complex) {
+            $complex = Complex::validateComplexArgument($complex);
 
-        $result = new Complex(
-            $real,
-            $imaginary,
-            ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
-        );
+            if ($result->isComplex() && $complex->isComplex() &&
+                $result->getSuffix() !== $complex->getSuffix()) {
+                throw new Exception('Suffix Mismatch');
+            }
+            if ($complex->getReal() == 0.0 && $complex->getImaginary() == 0.0) {
+                throw new \InvalidArgumentException('Division by zero');
+            }
+
+            $delta1 = ($result->getReal() * $complex->getReal()) +
+                ($result->getImaginary() * $complex->getImaginary());
+            $delta2 = ($result->getImaginary() * $complex->getReal()) -
+                ($result->getReal() * $complex->getImaginary());
+            $delta3 = ($complex->getReal() * $complex->getReal()) +
+                ($complex->getImaginary() * $complex->getImaginary());
+
+            $real = $delta1 / $delta3;
+            $imaginary = $delta2 / $delta3;
+
+            $result = new Complex(
+                $real,
+                $imaginary,
+                ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
+            );
+        }
+
+        return $result;
     }
-
-    return $result;
 }

--- a/classes/src/operations/divideinto.php
+++ b/classes/src/operations/divideinto.php
@@ -15,42 +15,44 @@ namespace Complex;
  * @param     array of string|integer|float|Complex    $complexValues   The numbers to divide
  * @return    Complex
  */
-function divideinto(...$complexValues): Complex
-{
-    if (count($complexValues) < 2) {
-        throw new \Exception('This function requires at least 2 arguments');
-    }
-
-    $base = array_shift($complexValues);
-    $result = clone Complex::validateComplexArgument($base);
-
-    foreach ($complexValues as $complex) {
-        $complex = Complex::validateComplexArgument($complex);
-
-        if ($result->isComplex() && $complex->isComplex() &&
-            $result->getSuffix() !== $complex->getSuffix()) {
-            throw new Exception('Suffix Mismatch');
-        }
-        if ($result->getReal() == 0.0 && $result->getImaginary() == 0.0) {
-            throw new \InvalidArgumentException('Division by zero');
+if (!function_exists(__NAMESPACE__ . '\\divideinto')) {
+    function divideinto(...$complexValues): Complex
+    {
+        if (count($complexValues) < 2) {
+            throw new \Exception('This function requires at least 2 arguments');
         }
 
-        $delta1 = ($complex->getReal() * $result->getReal()) +
-            ($complex->getImaginary() * $result->getImaginary());
-        $delta2 = ($complex->getImaginary() * $result->getReal()) -
-            ($complex->getReal() * $result->getImaginary());
-        $delta3 = ($result->getReal() * $result->getReal()) +
-            ($result->getImaginary() * $result->getImaginary());
+        $base = array_shift($complexValues);
+        $result = clone Complex::validateComplexArgument($base);
 
-        $real = $delta1 / $delta3;
-        $imaginary = $delta2 / $delta3;
+        foreach ($complexValues as $complex) {
+            $complex = Complex::validateComplexArgument($complex);
 
-        $result = new Complex(
-            $real,
-            $imaginary,
-            ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
-        );
+            if ($result->isComplex() && $complex->isComplex() &&
+                $result->getSuffix() !== $complex->getSuffix()) {
+                throw new Exception('Suffix Mismatch');
+            }
+            if ($result->getReal() == 0.0 && $result->getImaginary() == 0.0) {
+                throw new \InvalidArgumentException('Division by zero');
+            }
+
+            $delta1 = ($complex->getReal() * $result->getReal()) +
+                ($complex->getImaginary() * $result->getImaginary());
+            $delta2 = ($complex->getImaginary() * $result->getReal()) -
+                ($complex->getReal() * $result->getImaginary());
+            $delta3 = ($result->getReal() * $result->getReal()) +
+                ($result->getImaginary() * $result->getImaginary());
+
+            $real = $delta1 / $delta3;
+            $imaginary = $delta2 / $delta3;
+
+            $result = new Complex(
+                $real,
+                $imaginary,
+                ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
+            );
+        }
+
+        return $result;
     }
-
-    return $result;
 }

--- a/classes/src/operations/multiply.php
+++ b/classes/src/operations/multiply.php
@@ -15,34 +15,36 @@ namespace Complex;
  * @param     array of string|integer|float|Complex    $complexValues   The numbers to multiply
  * @return    Complex
  */
-function multiply(...$complexValues): Complex
-{
-    if (count($complexValues) < 2) {
-        throw new \Exception('This function requires at least 2 arguments');
-    }
-
-    $base = array_shift($complexValues);
-    $result = clone Complex::validateComplexArgument($base);
-
-    foreach ($complexValues as $complex) {
-        $complex = Complex::validateComplexArgument($complex);
-
-        if ($result->isComplex() && $complex->isComplex() &&
-            $result->getSuffix() !== $complex->getSuffix()) {
-            throw new Exception('Suffix Mismatch');
+if (!function_exists(__NAMESPACE__ . '\\multiply')) {
+    function multiply(...$complexValues): Complex
+    {
+        if (count($complexValues) < 2) {
+            throw new \Exception('This function requires at least 2 arguments');
         }
 
-        $real = ($result->getReal() * $complex->getReal()) -
-            ($result->getImaginary() * $complex->getImaginary());
-        $imaginary = ($result->getReal() * $complex->getImaginary()) +
-            ($result->getImaginary() * $complex->getReal());
+        $base = array_shift($complexValues);
+        $result = clone Complex::validateComplexArgument($base);
 
-        $result = new Complex(
-            $real,
-            $imaginary,
-            ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
-        );
+        foreach ($complexValues as $complex) {
+            $complex = Complex::validateComplexArgument($complex);
+
+            if ($result->isComplex() && $complex->isComplex() &&
+                $result->getSuffix() !== $complex->getSuffix()) {
+                throw new Exception('Suffix Mismatch');
+            }
+
+            $real = ($result->getReal() * $complex->getReal()) -
+                ($result->getImaginary() * $complex->getImaginary());
+            $imaginary = ($result->getReal() * $complex->getImaginary()) +
+                ($result->getImaginary() * $complex->getReal());
+
+            $result = new Complex(
+                $real,
+                $imaginary,
+                ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
+            );
+        }
+
+        return $result;
     }
-
-    return $result;
 }

--- a/classes/src/operations/subtract.php
+++ b/classes/src/operations/subtract.php
@@ -15,32 +15,34 @@ namespace Complex;
  * @param     array of string|integer|float|Complex    $complexValues   The numbers to subtract
  * @return    Complex
  */
-function subtract(...$complexValues): Complex
-{
-    if (count($complexValues) < 2) {
-        throw new \Exception('This function requires at least 2 arguments');
-    }
-
-    $base = array_shift($complexValues);
-    $result = clone Complex::validateComplexArgument($base);
-
-    foreach ($complexValues as $complex) {
-        $complex = Complex::validateComplexArgument($complex);
-
-        if ($result->isComplex() && $complex->isComplex() &&
-            $result->getSuffix() !== $complex->getSuffix()) {
-            throw new Exception('Suffix Mismatch');
+if (!function_exists(__NAMESPACE__ . '\\subtract')) {
+    function subtract(...$complexValues): Complex
+    {
+        if (count($complexValues) < 2) {
+            throw new \Exception('This function requires at least 2 arguments');
         }
 
-        $real = $result->getReal() - $complex->getReal();
-        $imaginary = $result->getImaginary() - $complex->getImaginary();
+        $base = array_shift($complexValues);
+        $result = clone Complex::validateComplexArgument($base);
 
-        $result = new Complex(
-            $real,
-            $imaginary,
-            ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
-        );
+        foreach ($complexValues as $complex) {
+            $complex = Complex::validateComplexArgument($complex);
+
+            if ($result->isComplex() && $complex->isComplex() &&
+                $result->getSuffix() !== $complex->getSuffix()) {
+                throw new Exception('Suffix Mismatch');
+            }
+
+            $real = $result->getReal() - $complex->getReal();
+            $imaginary = $result->getImaginary() - $complex->getImaginary();
+
+            $result = new Complex(
+                $real,
+                $imaginary,
+                ($imaginary == 0.0) ? null : max($result->getSuffix(), $complex->getSuffix())
+            );
+        }
+
+        return $result;
     }
-
-    return $result;
 }

--- a/unitTests/classes/src/operations/addTest.php
+++ b/unitTests/classes/src/operations/addTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Complex;
+
+class addTest extends BaseFunctionTestAbstract
+{
+    protected static $functionName = 'add';
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testAdd()
+    {
+        $args = func_get_args();
+        $complex1 = new Complex($args[0]);
+        $complex2 = new Complex($args[1]);
+        $result = add($complex1, $complex2);
+
+        $this->complexNumberAssertions($args[2], $result);
+        // Verify that the original complex values remains unchanged
+        $this->assertEquals(new Complex($args[0]), $complex1);
+        $this->assertEquals(new Complex($args[1]), $complex2);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '22.2215+11.11i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '22.2215+2.468i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '2.4685+11.11i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '2.4685+2.468i'],
+
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '22.2215-2.468i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '22.2215-11.11i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '2.4685-2.468i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '2.4685-11.11i'],
+
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-2.4685+11.11i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-2.4685+2.468i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-22.2215+11.11i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-22.2215+2.468i'],
+
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-2.4685-2.468i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-2.4685-11.11i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-22.2215-2.468i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-22.2215-11.11i'],
+        ];
+    }
+}

--- a/unitTests/classes/src/operations/divideByTest.php
+++ b/unitTests/classes/src/operations/divideByTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Complex;
+
+class divideByTest extends BaseFunctionTestAbstract
+{
+    protected static $functionName = 'divideby';
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testDivideBy()
+    {
+        $args = func_get_args();
+        $complex1 = new Complex($args[0]);
+        $complex2 = new Complex($args[1]);
+        $result = divideby($complex1, $complex2);
+
+        $this->complexNumberAssertions($args[2], $result);
+        // Verify that the original complex values remains unchanged
+        $this->assertEquals(new Complex($args[0]), $complex1);
+        $this->assertEquals(new Complex($args[1]), $complex2);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '1.3015443641332967+0.11795947983395175i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '0.7967051857421034+1.0359502969262013i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-0.7967051857421034-1.0359502969262013i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-1.3015443641332967-0.11795947983395175i'],
+
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '0.7967051857421034-1.0359502969262013i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '1.3015443641332967-0.11795947983395175i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-1.3015443641332967+0.11795947983395175i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-0.7967051857421034+1.0359502969262013i'],
+
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-0.7967051857421034+1.0359502969262013i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-1.3015443641332967+0.11795947983395175i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '1.3015443641332967-0.11795947983395175i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '0.7967051857421034-1.0359502969262013i'],
+
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-1.3015443641332967-0.11795947983395175i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-0.7967051857421034-1.0359502969262013i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '0.7967051857421034+1.0359502969262013i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '1.3015443641332967+0.11795947983395175i'],
+        ];
+    }
+}

--- a/unitTests/classes/src/operations/divideIntoTest.php
+++ b/unitTests/classes/src/operations/divideIntoTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Complex;
+
+class divideIntoTest extends BaseFunctionTestAbstract
+{
+    protected static $functionName = 'divideinto';
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testDivideInto()
+    {
+        $args = func_get_args();
+        $complex1 = new Complex($args[0]);
+        $complex2 = new Complex($args[1]);
+        $result = divideinto($complex1, $complex2);
+
+        $this->complexNumberAssertions($args[2], $result);
+        // Verify that the original complex values remains unchanged
+        $this->assertEquals(new Complex($args[0]), $complex1);
+        $this->assertEquals(new Complex($args[1]), $complex2);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '0.762058579649-0.06906567008823727i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '0.466473551710-0.606552364728i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-0.466473551710+0.606552364728i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-0.762058579649+0.06906567008823727i'],
+
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '0.466473551710+0.606552364728i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '0.762058579649-0.06906567008823727i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-0.762058579649-0.06906567008823727i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-0.466473551710-0.606552364728i'],
+
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-0.466473551710-0.606552364728i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-0.762058579649-0.06906567008823727i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '0.762058579649+0.06906567008823727i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '0.466473551710+0.606552364728i'],
+
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-0.762058579649+0.06906567008823727i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-0.466473551710+0.606552364728i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '0.466473551710-0.606552364728i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '0.762058579649-0.06906567008823727i'],
+        ];
+    }
+}

--- a/unitTests/classes/src/operations/multiplyTest.php
+++ b/unitTests/classes/src/operations/multiplyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Complex;
+
+class multiplyTest extends BaseFunctionTestAbstract
+{
+    protected static $functionName = 'multiply';
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testMultiply()
+    {
+        $args = func_get_args();
+        $complex1 = new Complex($args[0]);
+        $complex2 = new Complex($args[1]);
+        $result = multiply($complex1, $complex2);
+
+        $this->complexNumberAssertions($args[2], $result);
+        // Verify that the original complex values remains unchanged
+        $this->assertEquals(new Complex($args[0]), $complex1);
+        $this->assertEquals(new Complex($args[1]), $complex2);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '92.5901235+120.3943035i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '151.2606615+13.7088135i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-151.2606615-13.7088135i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-92.5901235-120.3943035i'],
+
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '151.2606615-13.7088135i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '92.5901235-120.3943035i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-92.5901235+120.3943035i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-151.2606615+13.7088135i'],
+
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-151.2606615+13.7088135i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-92.5901235+120.3943035i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '92.5901235-120.3943035i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '151.2606615-13.7088135i'],
+
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-92.5901235-120.3943035i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-151.2606615-13.7088135i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '151.2606615+13.7088135i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '92.5901235+120.3943035i'],
+        ];
+    }
+}

--- a/unitTests/classes/src/operations/subtractTest.php
+++ b/unitTests/classes/src/operations/subtractTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Complex;
+
+class subtractTest extends BaseFunctionTestAbstract
+{
+    protected static $functionName = 'subtract';
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testSubtract()
+    {
+        $args = func_get_args();
+        $complex1 = new Complex($args[0]);
+        $complex2 = new Complex($args[1]);
+        $result = subtract($complex1, $complex2);
+
+        $this->complexNumberAssertions($args[2], $result);
+        // Verify that the original complex values remains unchanged
+        $this->assertEquals(new Complex($args[0]), $complex1);
+        $this->assertEquals(new Complex($args[1]), $complex2);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '2.4685+2.468i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '2.4685+11.11i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '22.2215+2.468i'],
+            [ 'complex1' => [12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '22.2215+11.11i'],
+
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '2.4685-11.11i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '2.4685-2.468i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '22.2215-11.11i'],
+            [ 'complex1' => [12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '22.2215-2.468i'],
+
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-22.2215+2.468i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-22.2215+11.11i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-2.4685+2.468i'],
+            [ 'complex1' => [-12.345, 6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-2.4685+11.11i'],
+
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, 4.321, 'i'], 'expected' => '-22.2215-11.11i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [9.8765, -4.321, 'i'], 'expected' => '-22.2215-2.468i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, 4.321, 'i'], 'expected' => '-2.4685-11.11i'],
+            [ 'complex1' => [-12.345, -6.789, 'i'], 'complex2' => [-9.8765, -4.321, 'i'], 'expected' => '-2.4685-2.468i'],
+        ];
+    }
+}


### PR DESCRIPTION
Apply function-exists check around all function definitions. This is a problem for WP users who are using plug-ins that haven't been properly created with PHPScoper, and they blame my libraries rather than the plug-in creators, who don't understand how a plug-in is supposed to be scoped.

Also added a series of unit tests for operation functions (add, subtract, multipl, divideby and divideinto)