### PR TITLE
PHP8.1 Deprecation

### DIFF
--- a/classes/src/Complex.php
+++ b/classes/src/Complex.php
@@ -186,7 +186,7 @@ class Complex
         // Set parsed values in our properties
         $this->realPart = (float) $realPart;
         $this->imaginaryPart = (float) $imaginaryPart;
-        $this->suffix = strtolower($suffix);
+        $this->suffix = strtolower($suffix ?? '');
     }
 
     /**


### PR DESCRIPTION
One statement can pass a null to strtolower. This is deprecated in PHP8.1, and, when deprecated messages are enabled, causes 327 tests to error out in PhpSpreadsheet, and 598 in its own project. Use coercion to pass null string rather than null. A set of similar changes will be coming to PhpSpreadsheet this week.